### PR TITLE
Fixed server option with remote server, and dynamic urls

### DIFF
--- a/bin/Screenshooter.js
+++ b/bin/Screenshooter.js
@@ -31,7 +31,7 @@
       this.threads++;
       filename = process.cwd() + '/' + file.src[0];
       if (this.options.server !== '') {
-        filename = this.options.server + file.src[0].replace(file.orig.cwd, '');
+        filename = this.options.server + file.orig.src[0].replace(file.orig.cwd, '');
       }
 
       return this.ph.createPage(this.getPageCallback((function(_this) {


### PR DESCRIPTION
Current version has a bug, preventing making screenshots of non-existing files.
I.E. if file photos does not exist in your source tree.
You can test it with this configuration:
```
phantomjs_screenshot: {
		main: {
			options: {
			        server: "http://google.com"
			},
			files: {'screenshot.jpg': ['/'],
				'screenshot2.jpg': ['/photos']
				},
			
		}
	},
```